### PR TITLE
Update FAQ link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "content/doc"]
 	path = content/doc
-	url = https://github.com/libretro/Lakka.wiki.git
+	url = https://github.com/libretro/Lakka-LibreELEC.wiki.git


### PR DESCRIPTION
The [wiki link](https://github.com/libretro/Lakka-LibreELEC/wiki) need to be update to the new repo.