### PR TITLE
Fix branding spanning over 2 lines

### DIFF
--- a/partials/step-2.html
+++ b/partials/step-2.html
@@ -33,7 +33,7 @@
 	</a></div>
 	<div class="hummingboard col col-lg-3 col-md-4 col-sm-6"><a href="imx6.cuboxi">
 		<img alt="Allwinner HummingBoard" src="/images/hummingboard.jpg" />
-		<h3>Allwinner HummingBoard</h3>
+		<h3>HummingBoard</h3>
 		<p>Stable</p>
 	</a></div>
 	<div class="udoo col col-lg-3 col-md-4 col-sm-6"><a href="imx6.udoo">
@@ -53,7 +53,7 @@
 	</a></div>
 	<div class="odroidxu3 col col-lg-3 col-md-4 col-sm-6"><a href="odroidxu3">
 		<img alt="Hardkernel Odroid-XU3/4" src="/images/odroidxu4.jpg" />
-		<h3>Hardkernel Odroid-XU3/4</h3>
+		<h3>Odroid-XU3/4</h3>
 		<p>Stable</p>
 	</a></div>
 	<div class="wtk col col-lg-3 col-md-4 col-sm-6"><a href="wtk">
@@ -77,8 +77,8 @@
 		<p>Stable</p>
 	</a></div>
 	<div class="cb col col-lg-3 col-md-4 col-sm-6"><a href="allwinner">
-		<img alt="Cubieboard" src="/images/cubie1.jpg" />
-		<h3>Cubieboard</h3>
+		<img alt="Allwinner Cubieboard" src="/images/cubie1.jpg" />
+		<h3>Allwinner Cubieboard</h3>
 		<p>Stable</p>
 	</a></div>
 	<div class="cb2 col col-lg-3 col-md-4 col-sm-6"><a href="allwinner">


### PR DESCRIPTION
When the device name spans over two lines, there are blank spaces between the tiles, hence shortened some descriptions.