### PR TITLE
Etcher as default tool for image flashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Default location for output, needs to match output_dir's value found in config.yaml
 output/
+output
 
 # Temporary file directory
 tmp/

--- a/content/get/linux/S8X2.html
+++ b/content/get/linux/S8X2.html
@@ -41,7 +41,3 @@ next: install
     <span class="details">for T8 ~ 300MB</span></a>
   </p></div>
 </div>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/S8X2/install.html
+++ b/content/get/linux/S8X2/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/allwinner.html
+++ b/content/get/linux/allwinner.html
@@ -59,7 +59,3 @@ next: install
   <a href="<%= @config[:release][:'allwinner.orangepi_plus2e'] %>">Download Lakka
   <span class="details">for OrangePi Plus 2E ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/allwinner/install.html
+++ b/content/get/linux/allwinner/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/generic.html
+++ b/content/get/linux/generic.html
@@ -21,10 +21,6 @@ next: install
   <span class="details">for 64 bits CPU ~ 300MB</span></a>
 </p>
 
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>
-
 <p>Please note that due to the wide variety of PC hardware, Lakka may not work on your hardware.</p>
 
 <p>Those image are USB images, not CD or DVD images, those installation mediums are unsupported. Also, we don't support virtualization and dualboot. Lakka is meant to be installed on real hardware.</p>

--- a/content/get/linux/imx6.cuboxi.html
+++ b/content/get/linux/imx6.cuboxi.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:'imx6.cuboxi'] %>">Download Lakka
   <span class="details">for CuBox-i / HummingBoard ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/imx6.cuboxi/install.html
+++ b/content/get/linux/imx6.cuboxi/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/imx6.udoo.html
+++ b/content/get/linux/imx6.udoo.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:'imx6.udoo'] %>">Download Lakka
   <span class="details">for UDOO ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/imx6.udoo/install.html
+++ b/content/get/linux/imx6.udoo/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/miqi.html
+++ b/content/get/linux/miqi.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:miqi] %>">Download Lakka
   <span class="details">for MiQi ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/miqi/install.html
+++ b/content/get/linux/miqi/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/odroidc1.html
+++ b/content/get/linux/odroidc1.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:c1] %>">Download Lakka
   <span class="details">for Odroid-C1 ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/odroidc1/install.html
+++ b/content/get/linux/odroidc1/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/odroidc2.html
+++ b/content/get/linux/odroidc2.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:c2] %>">Download Lakka
   <span class="details">for Odroid-C2 ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/odroidc2/install.html
+++ b/content/get/linux/odroidc2/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/odroidxu3.html
+++ b/content/get/linux/odroidxu3.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:xu3] %>">Download Lakka
   <span class="details">for Odroid-XU3/4 ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/odroidxu3/install.html
+++ b/content/get/linux/odroidxu3/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/rock64.html
+++ b/content/get/linux/rock64.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:rock64] %>">Download Lakka
   <span class="details">for ROCK64 ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/rock64/install.html
+++ b/content/get/linux/rock64/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/rpi.html
+++ b/content/get/linux/rpi.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:rpi] %>">Download Lakka
   <span class="details">for Raspberry Pi ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/rpi/install.html
+++ b/content/get/linux/rpi/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/rpi2.html
+++ b/content/get/linux/rpi2.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:rpi2] %>">Download Lakka
   <span class="details">for Raspberry Pi 2/3 ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/rpi2/install.html
+++ b/content/get/linux/rpi2/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/s805.html
+++ b/content/get/linux/s805.html
@@ -36,7 +36,3 @@ next: install
     <span class="details">for MXQ ~ 300MB</span></a>
   </p></div>
 </div>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/s805/install.html
+++ b/content/get/linux/s805/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/s905.html
+++ b/content/get/linux/s905.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:s905] %>">Download Lakka
   <span class="details">for S905 ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/s905/install.html
+++ b/content/get/linux/s905/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/s912.html
+++ b/content/get/linux/s912.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:s912] %>">Download Lakka
   <span class="details">for S912 ~ 312MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/s912/install.html
+++ b/content/get/linux/s912/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/tkb.html
+++ b/content/get/linux/tkb.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:tkb] %>">Download Lakka
   <span class="details">for Tinker Board ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/tkb/install.html
+++ b/content/get/linux/tkb/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/wtk.html
+++ b/content/get/linux/wtk.html
@@ -19,7 +19,3 @@ next: install
   <a href="<%= @config[:release][:wtk2] %>">Download Lakka
   <span class="details">for WeTek Play 2 ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/wtk/install.html
+++ b/content/get/linux/wtk/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/wtkcore.html
+++ b/content/get/linux/wtkcore.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:wtkcore] %>">Download Lakka
   <span class="details">for WeTek Core ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/wtkcore/install.html
+++ b/content/get/linux/wtkcore/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/linux/wtkhub.html
+++ b/content/get/linux/wtkhub.html
@@ -14,7 +14,3 @@ next: install
   <a href="<%= @config[:release][:wtkhub] %>">Download Lakka
   <span class="details">for WeTek Hub ~ 300MB</span></a>
 </p>
-
-<p>On Linux, you can use the command line tool gunzip to extract Lakka.</p>
-
-<p>Alternatively, your desktop environment is supposed to provide a graphical way to unzip.</p>

--- a/content/get/linux/wtkhub/install.html
+++ b/content/get/linux/wtkhub/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-linux-sd.md' %>
 <% end %>

--- a/content/get/macos/S8X2.html
+++ b/content/get/macos/S8X2.html
@@ -41,5 +41,3 @@ next: install
     <span class="details">for T8 ~ 300MB</span></a>
   </p></div>
 </div>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/S8X2/install.html
+++ b/content/get/macos/S8X2/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/allwinner.html
+++ b/content/get/macos/allwinner.html
@@ -59,5 +59,3 @@ next: install
   <a href="<%= @config[:release][:'allwinner.orangepi_plus2e'] %>">Download Lakka
   <span class="details">for OrangePi Plus 2E ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/allwinner/install.html
+++ b/content/get/macos/allwinner/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/generic.html
+++ b/content/get/macos/generic.html
@@ -21,8 +21,6 @@ next: install
   <span class="details">for 64 bits CPU ~ 300MB</span></a>
 </p>
 
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>
-
 <p>Please note that due to the wide variety of PC hardware, Lakka may not work on your hardware.</p>
 
 <p>Those image are USB images, not CD or DVD images, those installation mediums are unsupported. Also, we don't support virtualization and dualboot. Lakka is meant to be installed on real hardware.</p>

--- a/content/get/macos/imx6.cuboxi.html
+++ b/content/get/macos/imx6.cuboxi.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:'imx6.cuboxi'] %>">Download Lakka
   <span class="details">for CuBox-i / HummingBoard ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/imx6.cuboxi/install.html
+++ b/content/get/macos/imx6.cuboxi/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/imx6.html
+++ b/content/get/macos/imx6.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:imx6] %>">Download Lakka
   <span class="details">for CuBox-i / HummingBoard ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/imx6.udoo.html
+++ b/content/get/macos/imx6.udoo.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:'imx6.udoo'] %>">Download Lakka
   <span class="details">for UDOO ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/imx6.udoo/install.html
+++ b/content/get/macos/imx6.udoo/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/imx6/install.html
+++ b/content/get/macos/imx6/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/miqi.html
+++ b/content/get/macos/miqi.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:miqi] %>">Download Lakka
   <span class="details">for MiQi ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/miqi/install.html
+++ b/content/get/macos/miqi/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/odroidc1.html
+++ b/content/get/macos/odroidc1.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:c1] %>">Download Lakka
   <span class="details">for Odroid-C1 ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/odroidc1/install.html
+++ b/content/get/macos/odroidc1/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/odroidc2.html
+++ b/content/get/macos/odroidc2.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:c2] %>">Download Lakka
   <span class="details">for Odroid-C2 ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/odroidc2/install.html
+++ b/content/get/macos/odroidc2/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/odroidxu3.html
+++ b/content/get/macos/odroidxu3.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:xu3] %>">Download Lakka
   <span class="details">for Odroid-XU3/4 ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/odroidxu3/install.html
+++ b/content/get/macos/odroidxu3/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/rock64.html
+++ b/content/get/macos/rock64.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:rock64] %>">Download Lakka
   <span class="details">for ROCK64 ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/rock64/install.html
+++ b/content/get/macos/rock64/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/rpi.html
+++ b/content/get/macos/rpi.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:rpi] %>">Download Lakka
   <span class="details">for Raspberry Pi ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/rpi/install.html
+++ b/content/get/macos/rpi/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/rpi2.html
+++ b/content/get/macos/rpi2.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:rpi2] %>">Download Lakka
   <span class="details">for Raspberry Pi 2/3 ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/rpi2/install.html
+++ b/content/get/macos/rpi2/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/s805.html
+++ b/content/get/macos/s805.html
@@ -36,5 +36,3 @@ next: install
     <span class="details">for MXQ ~ 300MB</span></a>
   </p></div>
 </div>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/s805/install.html
+++ b/content/get/macos/s805/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/s905.html
+++ b/content/get/macos/s905.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:s905] %>">Download Lakka
   <span class="details">for S905 ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/s905/install.html
+++ b/content/get/macos/s905/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/s912.html
+++ b/content/get/macos/s912.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:s912] %>">Download Lakka
   <span class="details">for S912 ~ 312MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/s912/install.html
+++ b/content/get/macos/s912/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/tkb.html
+++ b/content/get/macos/tkb.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:tkb] %>">Download Lakka
   <span class="details">for Tinker Board ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/tkb/install.html
+++ b/content/get/macos/tkb/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/wtk.html
+++ b/content/get/macos/wtk.html
@@ -19,5 +19,3 @@ next: install
   <a href="<%= @config[:release][:wtk2] %>">Download Lakka
   <span class="details">for WeTek Play 2 ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/wtk/install.html
+++ b/content/get/macos/wtk/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/wtkcore.html
+++ b/content/get/macos/wtkcore.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:wtkcore] %>">Download Lakka
   <span class="details">for WeTek Core ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/wtkcore/install.html
+++ b/content/get/macos/wtkcore/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/macos/wtkhub.html
+++ b/content/get/macos/wtkhub.html
@@ -14,5 +14,3 @@ next: install
   <a href="<%= @config[:release][:wtkhub] %>">Download Lakka
   <span class="details">for WeTek Hub ~ 300MB</span></a>
 </p>
-
-<p>On MacOS, you just have to double click on the downloaded archive to unzip Lakka.</p>

--- a/content/get/macos/wtkhub/install.html
+++ b/content/get/macos/wtkhub/install.html
@@ -5,6 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<% filter :kramdown do %>
+<% filter :erb do %>
 <%= partial 'step-4-macos-sd.md' %>
 <% end %>

--- a/content/get/windows/generic/install.html
+++ b/content/get/windows/generic/install.html
@@ -5,35 +5,6 @@ previous: true
 next: first-boot
 ---
 
-<h2>Create your installation medium</h2>
-
-<p>To setup Lakka on a PC, you have to create a Live USB installer. You need a USB pendrive of at least 512mo. All data on this drive will be completely lost.</p>
-
-<h3>Download Windows image flasher utility</h3>
-
-<p>On Windows, you will need a graphical tool to flash Lakka to your USB stick.</p>
-
-<p>This tool is called Win32DiskImager and is free.</p>
-
-<%= render 'partials/dl-button',
-      :url => 'http://sourceforge.net/projects/win32diskimager/',
-      :detail => 'for Windows ~ 17MB',
-      :what => 'Win32DiskImager' %>
-
-<h3>Setup Windows image flasher utility</h3>
-
-<img src="/images/win32diskmanager1.png" alt="Win32 Disk Imager Installation utility" />
-
-<h3>Determine your USB drive</h3>
-
-<p>Open your File Manager, and plug your USB stick.</p>
-
-<p>You will see a new drive appearing in your File Manager.</p>
-
-<h3>Flash the image</h3>
-
-<p>Run the Win32DiskImager you just installed.</p>
-
-<img src="/images/win32diskmanager2.png" alt="Win32 Disk Imager" />
-
-<p>Select Lakka and the USB drive, and hit the Write button.</p>
+<% filter :erb do %>
+<%= partial 'step-4-windows-sd.html' %>
+<% end %>

--- a/partials/step-4-linux-sd.md
+++ b/partials/step-4-linux-sd.md
@@ -1,51 +1,22 @@
-## Install Lakka to the SD card
+<h2>Flashing Lakka image</h2>
 
-### Determining your SD card drive
+<h3>Downloading image flasher utility</h3>
 
-First, you need to know which drive your SD card is.
+<p>To flash the downloaded Lakka image to your SD card or USB thumb drive we recommend using graphical tool called Etcher. Etcher can work with compressed <code>.img.gz</code> files, so it is not required to decompress the downloaded image file.</p>
 
-List your current drives and partitions with:
+<p>You can download Etcher from the link below. It is free/open source software.</p>
 
-    $ ls -l /dev/sd*
+<%= render 'partials/dl-button',
+      :url => 'https://etcher.io/',
+      :detail => 'for Linux',
+      :what => 'Etcher' %>
 
-You will see a list of files, in my case:
+<h3>Flash the image</h3>
 
-    brw-rw---- 1 root disk  8,  0 22 mars  23:01 /dev/sda
-    brw-rw---- 1 root disk  8,  1 22 mars  23:01 /dev/sda1
-    brw-rw---- 1 root disk  8,  2 22 mars  23:01 /dev/sda2
-    brw-rw---- 1 root disk  8,  3 22 mars  23:01 /dev/sda3
-    brw-rw---- 1 root disk  8,  4 22 mars  23:01 /dev/sda4
-    brw-rw---- 1 root disk  8,  5 22 mars  23:01 /dev/sda5
-    brw-rw-r-- 1 root users 8, 16 22 mars  23:01 /dev/sdb
+<p>Run Etcher.</p>
 
-Those ending with numbers are partitions, while those ending in letters are other drives. In my case, _sda_ is my hard drive, and _sda1_ to _sda5_ are my partitions.
+<img alt="Etcher" style="width: 100%; max-width: 840px; margin: 15px 0;" src="/images/etcher.gif" />
 
-Now plug in your SD card, and again type:
+<p>Select the Lakka image, select the drive and hit the Flash button.</p>
 
-    $ ls -l /dev/sd*
-
-Once again, in my case:
-
-    brw-rw---- 1 root disk  8,  0 22 mars  23:01 /dev/sda
-    brw-rw---- 1 root disk  8,  1 22 mars  23:01 /dev/sda1
-    brw-rw---- 1 root disk  8,  2 22 mars  23:01 /dev/sda2
-    brw-rw---- 1 root disk  8,  3 22 mars  23:01 /dev/sda3
-    brw-rw---- 1 root disk  8,  4 22 mars  23:01 /dev/sda4
-    brw-rw---- 1 root disk  8,  5 22 mars  23:01 /dev/sda5
-    brw-rw-r-- 1 root users 8, 16 22 mars  23:49 /dev/sdb
-    brw-rw---- 1 root disk  8, 17 22 mars  23:49 /dev/sdb1
-    brw-rw---- 1 root disk  8, 18 22 mars  23:49 /dev/sdb2
-
-Notice that _sdb_ is now filled with one or more partitions. In my case, _sdb1_ and _sdb2_
-
-This means that _sdb_ represents the SD card reader on my laptop. On yours, it can be a different letter. Please adapt the rest of this tutorial to your drive letter.
-
-### Flashing the image
-
-Now that you know your SD card drive, go to where you extracted Lakka, and flash the card:
-
-    $ sudo dd if=Lakka-*.img of=/dev/sdX
-
-Where _sdX_ is your SD card drive.
-
-It should take a few minutes, wait for the prompt. Once done, you can unplug your SD card and proceed to the next step.
+<p>In case you cannot use Etcher, look at the <a href="/doc/Alternative-image-flashing-methods/">alternative flashing methods</a>.</p>

--- a/partials/step-4-macos-sd.md
+++ b/partials/step-4-macos-sd.md
@@ -1,43 +1,22 @@
-## Install Lakka to the SD card
+<h2>Flashing Lakka image</h2>
 
-###  Determining your SD card drive
+<h3>Downloading image flasher utility</h3>
 
-First, you need to know which drive is your SD card.
+<p>To flash the downloaded Lakka image to your SD card or USB thumb drive we recommend using graphical tool called Etcher. Etcher can work with compressed <code>.img.gz</code> files, so it is not required to decompress the downloaded image file.</p>
 
-Open a Console and list your current drives and partitions with:
+<p>You can download Etcher from the link below. It is free/open source software.</p>
 
-    $ diskutil list
+<%= render 'partials/dl-button',
+      :url => 'https://etcher.io/',
+      :detail => 'for MacOS',
+      :what => 'Etcher' %>
 
-This command should output something similar to this
+<h3>Flash the image</h3>
 
-![Disks lists](/images/diskutil1.png)
+<p>Run Etcher.</p>
 
-In my case, disk0 is my hard drive, and disk0s1 to disk0s5 are my partitions.
+<img alt="Etcher" style="width: 100%; max-width: 840px; margin: 15px 0;" src="/images/etcher.gif" />
 
-Now plug in your SD card, and type again:
+<p>Select the Lakka image, select the drive and hit the Flash button.</p>
 
-![Disks lists and SD cards](/images/diskutil2.png)
-
-### Flashing the image
-
-Now that you know your SD card drive, go to where you extracted Lakka, and flash the card.
-
-Please note that dd is a very dangerous command: if you give it the wrong drive identifier, it could erase your hard drive instead of the SD card!
-
-    $ sudo dd if=Lakka-*.img of=/dev/rdiskN
-
-Where diskN is your SD card drive.
-
-![Flashing SD card](/images/macosdd.png)
-
-It should take a few minutes, wait for the prompt. Once done, you can unplug your SD card and proceed to the next step.
-
-If you get this error:
-
-    dd: /dev/disk4s1: Resource busy
-
-You have to unmount every partition of your SD card, this can be done with:
-
-    diskutil unmountDisk /dev/diskN
-
-And then you can retry the dd step.
+<p>In case you cannot use Etcher, look at the <a href="/doc/Alternative-image-flashing-methods/">alternative flashing methods</a>.</p>

--- a/partials/step-4-windows-sd.html
+++ b/partials/step-4-windows-sd.html
@@ -1,14 +1,14 @@
-<h2>Installing Lakka to the drive</h2>
+<h2>Flashing Lakka image</h2>
 
-<h3>Downloading Windows image flasher utility</h3>
+<h3>Downloading image flasher utility</h3>
 
-<p>On Windows, you need a graphical tool to flash Lakka to your SD Card or USB drive.</p>
+<p>To flash the downloaded Lakka image to your SD card or USB thumb drive we recommend using graphical tool called Etcher. Etcher can work with compressed <code>.img.gz</code> files, so it is not required to decompress the downloaded image file.</p>
 
-<p>This tool is called Etcher, and it is free.</p>
+<p>You can download Etcher from the link below. It is free/open source software.</p>
 
 <%= render 'partials/dl-button',
       :url => 'https://etcher.io/',
-      :detail => 'for Windows ~ 82MB',
+      :detail => 'for Windows',
       :what => 'Etcher' %>
 
 <h3>Flash the image</h3>
@@ -17,4 +17,6 @@
 
 <img alt="Etcher" style="width: 100%; max-width: 840px; margin: 15px 0;" src="/images/etcher.gif" />
 
-<p>Select the Lakka image and select the drive, and hit the Flash button.</p>
+<p>Select the Lakka image, select the drive and hit the Flash button.</p>
+
+<p>In case you cannot use Etcher, look at the <a href="/doc/Alternative-image-flashing-methods/">alternative flashing methods</a>.</p>


### PR DESCRIPTION
As Etcher can be used on all major operating systems, I have rewritten the flashing instructions for Linux and MacOS. Instructions for Windows already had Etcher in their instructions (except for Generic). I have also removed the instruction regarding decompression of the downloaded image file (Linux, MacOS).

I added a new page to the Lakka wiki with [alternative flashing instructions](https://github.com/libretro/Lakka-LibreELEC/wiki/Alternative-image-flashing-methods) which preserves the original instructions for different operating systems. Also a link to the doc page is included in the flashing instructions.

This solves https://github.com/lakkatv/lakka-website/issues/24 and https://github.com/libretro/Lakka-LibreELEC/issues/533.