### PR TITLE
fix references within the same page

### DIFF
--- a/lib/doc_link_filter.rb
+++ b/lib/doc_link_filter.rb
@@ -6,7 +6,11 @@ class DocLinksFilter < Nanoc::Filter
     filtered = "#{content}"
     needles = filtered.scan /href="[^http|irc][^"]*"/
     needles.each do |needle|
-      replacement = needle.sub '="', '="/doc/'
+      if needle[6,1] != '#'
+        replacement = needle.sub '="', '="/doc/'
+      else
+        replacement = needle
+      end
       filtered.sub! needle, replacement
     end 
     filtered


### PR DESCRIPTION
fixes #47

if the reference is within the same page (i.e. starts with #), the href was created as /doc/#..., instead leaving the reference intact (#...).

Compare the behavior at [1] and [2] by clicking the "Authorize the Dualshock Controller":
[1] current Lakka website: https://www.lakka.tv/doc/wireless-dualshock/
=> gets you to https://www.lakka.tv/doc/#authorize-the-dualshock-controller => Page not found - not wanted

[2] recompiled page after this change: http://lakka.vudiq.sk/doc/Wireless-Dualshock/
=> gets you to http://lakka.vudiq.sk/doc/Wireless-Dualshock/#authorize-the-dualshock-controller => the sub-chapter on the same page - wanted

*Disclaimer: this is my first rendezvous with ruby*